### PR TITLE
Tabs and username

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -16,10 +16,10 @@ class LoginForm(FlaskForm):
 
 
 class RegistrationForm(FlaskForm):
-    name = StringField('Name', validators=[
+    name = StringField('Username', validators=[
         DataRequired(),
         Length(min=2, max=80),
-        Regexp(r'^[a-zA-Z0-9_]+$', message='Name must contain only letters, numbers, and underscores.')],
+        Regexp(r'^[a-zA-Z0-9_]+$', message='Username must contain only letters, numbers, and underscores.')],
                        render_kw={'placeholder': 'Display name'})
     email = StringField('Email', validators=[
         DataRequired(),
@@ -50,10 +50,10 @@ class RegistrationForm(FlaskForm):
             raise ValidationError('Password must contain at least one letter and one digit.')
 
 class EditProfileForm(FlaskForm):
-    name = StringField('Name', validators=[
+    name = StringField('Username', validators=[
         DataRequired(),
         Length(min=2, max=80),
-        Regexp(r'^[a-zA-Z0-9_]+$', message='Name must contain only letters, numbers, and underscores.')],
+        Regexp(r'^[a-zA-Z0-9_]+$', message='Username must contain only letters, numbers, and underscores.')],
                        render_kw={'placeholder': 'Display name'})
     email = StringField('Email', validators=[
         DataRequired(),

--- a/app/models.py
+++ b/app/models.py
@@ -10,7 +10,8 @@ from app.extensions import db
 class HoursLog(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     hours_added = db.Column(db.Integer, nullable=False)
-    added_by = db.Column(db.String(255), nullable=False)  # The name or email of the volunteering organization who added the hours
+    added_by_email = db.Column(db.String(255), nullable=False) # The email of the volunteering organization who added the hours
+    added_by_username = db.Column(db.String(80), nullable=False)  # The username of the volunteering organization who added the hours
     added_to = db.Column(db.String(255), nullable=False)  # The email of the user who received the hours
     timestamp = db.Column(db.DateTime, default=datetime.utcnow)  # When the hours were added
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -152,7 +152,8 @@ def add_hours():
 
                 # Log the addition of hours
                 log_entry = HoursLog(hours_added=form.hours.data,
-                                     added_by=current_user.email,
+                                     added_by_email=current_user.email,
+                                     added_by_username=current_user.name,
                                      added_to=user.email)
                 db.session.add(log_entry)
                 db.session.commit()

--- a/app/routes.py
+++ b/app/routes.py
@@ -18,11 +18,11 @@ def load_user(user_id):
 @routes_bp.route("/")
 @login_required
 def home():
-    return render_template('index.html')
+    return render_template('index.html', active_tab='home')
 
 @routes_bp.route("/information")
 def info():
-    return render_template('home.html')
+    return render_template('home.html', active_tab='info')
 
 
 @routes_bp.route("/edit_profile", methods=['GET', 'POST'])
@@ -42,7 +42,7 @@ def edit_profile():
     form.name.data = current_user.name
     form.email.data = current_user.email
 
-    return render_template('edit_profile.html', form=form)
+    return render_template('edit_profile.html', form=form, active_tab='profile')
 
 
 
@@ -66,7 +66,7 @@ def login():
         else:
             flash("Invalid email or password", 'danger')
 
-    return render_template('auth/login.html', form=form)
+    return render_template('auth/login.html', form=form, active_tab='login')
 
 
 @routes_bp.route("/register", methods=['GET', 'POST'])
@@ -102,7 +102,7 @@ def register():
 def user_profile(name):
     user = User.query.filter_by(name=name).one_or_none()
     hours_logs = HoursLog.query.filter_by(added_to=user.email).all()
-    return render_template('user.html', user=user, hours_logs=hours_logs)
+    return render_template('user.html', user=user, hours_logs=hours_logs, active_tab='profile')
 
 @routes_bp.route("/rewards")
 @login_required
@@ -124,7 +124,7 @@ def rewards():
     if user.hours_volunteered >= 10:
         user_rewards.append(rewards[0])  # Bronze Badge
 
-    return render_template('rewards.html', rewards=user_rewards)
+    return render_template('rewards.html', rewards=user_rewards, active_tab='rewards')
 
 
 @routes_bp.route("/add_hours", methods=['GET', 'POST'])
@@ -165,7 +165,7 @@ def add_hours():
 
         return redirect(url_for('routes.add_hours'))
 
-    return render_template('add_hours.html', form=form, email_invalid=email_invalid)
+    return render_template('add_hours.html', form=form, email_invalid=email_invalid, active_tab='add-hours')
 
 
 @routes_bp.route("/remove_user", methods=['GET', 'POST'])
@@ -189,7 +189,7 @@ def remove_user():
 
         return redirect(url_for('routes.remove_user'))
 
-    return render_template('remove_user.html', form=form)
+    return render_template('remove_user.html', form=form, active_tab='remove-user')
 
 @routes_bp.route("/view_database", methods=['GET', 'POST'])
 @login_required
@@ -205,7 +205,7 @@ def view_database():
     else:
         users = User.query.all()
 
-    return render_template('view_database.html', users=users)
+    return render_template('view_database.html', users=users, active_tab='database')
 
 
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -22,38 +22,38 @@
 
 <ul class="nav nav-tabs">
     <li class="nav-item">
-        <a class="nav-link active" href="{{ url_for('routes.home') }}">Home</a>
+        <a class="nav-link {% if active_tab == 'home' %}active{% endif %}" href="{{ url_for('routes.home') }}">Home</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="{{ url_for('routes.info') }}">Information</a>
+        <a class="nav-link {% if active_tab == 'info' %}active{% endif %}" href="{{ url_for('routes.info') }}">Information</a>
     </li>
     {% if current_user.is_anonymous %}
         <li class="nav-item">
-            <a class="nav-link" href="{{ url_for('routes.login') }}">Login</a>
+            <a class="nav-link {% if active_tab == 'login' %}active{% endif %}" href="{{ url_for('routes.login') }}">Login</a>
         </li>
     {% else %}
         {% if current_user.role == 'volunteer' %}
             <li class="nav-item">
-                <a class="nav-link" href="{{ url_for('routes.rewards') }}">My Rewards</a>
+                <a class="nav-link {% if active_tab == 'rewards' %}active{% endif %}" href="{{ url_for('routes.rewards') }}">My Rewards</a>
             </li>
         {% endif %}
 
         <li class="nav-item">
-            <a class="nav-link" href="{{ url_for('routes.user_profile', name=current_user.name) }}">Profile</a>
+            <a class="nav-link {% if active_tab == 'profile' %}active{% endif %}" href="{{ url_for('routes.user_profile', name=current_user.name) }}">Profile</a>
         </li>
 
         {% if current_user.role != 'volunteer' %} {# This means admins and volunteering orgs can add hours #}
             <li class="nav-item">
-                <a class="nav-link" href="{{ url_for('routes.add_hours') }}">Add Hours</a>
+                <a class="nav-link {% if active_tab == 'add-hours' %}active{% endif %}" href="{{ url_for('routes.add_hours') }}">Add Hours</a>
             </li>
         {% endif %}
 
         {% if current_user.role == 'admin' %}
             <li class="nav-item">
-                <a class="nav-link" href="{{ url_for('routes.remove_user') }}">Admin - Remove User</a>
+                <a class="nav-link {% if active_tab == 'remove-user' %}active{% endif %}" href="{{ url_for('routes.remove_user') }}">Admin - Remove User</a>
             <li>
             <li class="nav-item">
-                <a class="nav-link" href="{{ url_for('routes.view_database') }}">Admin - View Database</a>
+                <a class="nav-link {% if active_tab == 'database' %}active{% endif %}" href="{{ url_for('routes.view_database') }}">Admin - View Database</a>
             <li>
         {% endif %}
 

--- a/templates/user.html
+++ b/templates/user.html
@@ -18,7 +18,8 @@
             <thead>
                 <tr>
                     <th>Hours Added</th>
-                    <th>Added By</th>
+                    <th>Added By (Email)</th>
+                    <th>Added By (Username)</th>
                     <th>Date</th>
                 </tr>
             </thead>
@@ -26,12 +27,14 @@
                 {% for log in hours_logs %}
                     <tr>
                         <td>{{ log.hours_added }}</td>
-                        <td>{{ log.added_by }}</td>
+                        {# switch to added_by_email and added_by_username? #}
+                        <td>{{ log.added_by_email }}</td>
+                        <td>{{ log.added_by_username }}</td>
                         <td>{{ log.timestamp.strftime('%Y-%m-%d') }}</td>
                     </tr>
                 {% else %}
                     <tr>
-                        <td colspan="3">No hours have been added yet.</td>
+                        <td colspan="4">No hours have been added yet.</td>
                     </tr>
                 {% endfor %}
             </tbody>


### PR DESCRIPTION
Made the tab activation work for tabs other than 'home' when they are clicked on and switched from displaying 'name' to 'username' above the name field when logging in or creating a profile, since name implies legal name, which would contain spaces, and we do not allow users to have spaces here. Updated DB to store both username and email of organizations when they log hours for a volunteer, and display both of these in the table on the volunteer's end